### PR TITLE
Always read cache

### DIFF
--- a/src/commonMain/kotlin/com/configcat/ConfigService.kt
+++ b/src/commonMain/kotlin/com/configcat/ConfigService.kt
@@ -67,7 +67,7 @@ internal class ConfigService constructor(
             }
 
             else -> {
-                val result = fetchIfOlder(Constants.distantPast, preferCached = true)
+                val result = fetchIfOlder(Constants.distantPast, preferCached = initialized.value) // If we are initialized, we prefer the cached results
                 if (result.first.isEmpty()) {
                     SettingResult.empty
                 } else {
@@ -106,29 +106,21 @@ internal class ConfigService constructor(
     }
 
     @Suppress("ComplexMethod")
-    private suspend fun fetchIfOlder(time: DateTime, preferCached: Boolean = false): Pair<Entry, String?> {
+    private suspend fun fetchIfOlder(threshold: DateTime, preferCached: Boolean = false): Pair<Entry, String?> {
         mutex.withLock {
             // Sync up with the cache and use it when it's not expired.
-            if (cachedEntry.isEmpty() || cachedEntry.fetchTime > time) {
-                val entry = readCache()
-                if (!entry.isEmpty() && entry.eTag != cachedEntry.eTag) {
-                    cachedEntry = entry
-                    hooks.invokeOnConfigChanged(entry.config.settings)
-                }
-                // Cache isn't expired
-                if (cachedEntry.fetchTime > time) {
-                    setInitialized()
-                    return Pair(cachedEntry, null)
-                }
+            val fromCache = readCache()
+            if (!fromCache.isEmpty() && fromCache.eTag != cachedEntry.eTag) {
+                hooks.invokeOnConfigChanged(fromCache.config.settings)
+                cachedEntry = fromCache
             }
-            // Use cache anyway (get calls on auto & manual poll must not initiate fetch).
-            // The initialized check ensures that we subscribe for the ongoing fetch during the
-            // max init wait time window in case of auto poll.
-            if (preferCached && initialized.value) {
+            // Cache isn't expired
+            if (cachedEntry.fetchTime > threshold) {
+                setInitialized()
                 return Pair(cachedEntry, null)
             }
-            // If we are in offline mode we are not allowed to initiate fetch.
-            if (offline.value) {
+            // If we are in offline mode or the caller prefers cached values, do not initiate fetch.
+            if (offline.value || preferCached) {
                 return Pair(cachedEntry, null)
             }
 

--- a/src/commonTest/kotlin/com/configcat/Utils.kt
+++ b/src/commonTest/kotlin/com/configcat/Utils.kt
@@ -72,6 +72,11 @@ internal object Data {
         return "${fetchTimeUnixSeconds}\n$value\n" + """{"f":{"fakeKey":{"v":$value}}}"""
     }
 
+    fun formatCacheEntryWithEtag(value: Any, etag: String): String {
+        val fetchTimeUnixSeconds = DateTime.now().unixMillis.toLong()
+        return "${fetchTimeUnixSeconds}\n$etag\n" + """{"f":{"fakeKey":{"v":$value}}}"""
+    }
+
     fun formatCacheEntryWithDate(value: Any, time: DateTime): String {
         val fetchTimeUnixSeconds = time.unixMillis.toLong()
         return "${fetchTimeUnixSeconds}\n$value\n" + """{"f":{"fakeKey":{"v":$value}}}"""


### PR DESCRIPTION
### Describe the purpose of your pull request

Before, the cache was read only when the in-memory "cache entry" was expired. This PR changes this behavior to reading the cache always and determining the expiration based on the external cache's TTL.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
