### PR TITLE
Fix auto poll initial config load from cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.configcat
-version=3.1.0
+version=3.1.1
 
 ktorVersion=2.3.10
 kotlinxSerializationVersion=1.6.3

--- a/src/commonMain/kotlin/com/configcat/ConfigService.kt
+++ b/src/commonMain/kotlin/com/configcat/ConfigService.kt
@@ -65,24 +65,26 @@ internal class ConfigService(
     }
 
     suspend fun getSettings(): SettingResult {
-        val result = when (mode) {
-            is LazyLoadMode -> {
-                fetchIfOlder(
-                    DateTime.now()
-                        .add(0, -mode.configuration.cacheRefreshInterval.inWholeMilliseconds.toDouble()),
-                )
-            }
-            else -> {
-                // If we are initialized, we prefer the cached results
-                val threshold = if (!initialized.value && mode is AutoPollMode) {
-                    DateTime.now()
-                        .add(0, -mode.configuration.pollingInterval.inWholeMilliseconds.toDouble())
-                } else {
-                    Constants.distantPast
+        val result =
+            when (mode) {
+                is LazyLoadMode -> {
+                    fetchIfOlder(
+                        DateTime.now()
+                            .add(0, -mode.configuration.cacheRefreshInterval.inWholeMilliseconds.toDouble()),
+                    )
                 }
-                fetchIfOlder(threshold, preferCached = initialized.value)
+                else -> {
+                    // If we are initialized, we prefer the cached results
+                    val threshold =
+                        if (!initialized.value && mode is AutoPollMode) {
+                            DateTime.now()
+                                .add(0, -mode.configuration.pollingInterval.inWholeMilliseconds.toDouble())
+                        } else {
+                            Constants.distantPast
+                        }
+                    fetchIfOlder(threshold, preferCached = initialized.value)
+                }
             }
-        }
         return if (result.first.isEmpty()) {
             SettingResult.empty
         } else {

--- a/src/commonMain/kotlin/com/configcat/Constants.kt
+++ b/src/commonMain/kotlin/com/configcat/Constants.kt
@@ -23,7 +23,7 @@ internal interface Closeable {
 }
 
 internal object Constants {
-    const val VERSION: String = "3.1.0"
+    const val VERSION: String = "3.1.1"
     const val CONFIG_FILE_NAME: String = "config_v6.json"
     const val SERIALIZATION_FORMAT_VERSION: String = "v2"
     const val GLOBAL_CDN_URL = "https://cdn-global.configcat.com"


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix initial config JSON load when auto poll enabled with results from cache.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
