### PR TITLE
Add snapshot parameter to onReady / onConfigChanged hooks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,8 @@
 group=com.configcat
-version=4.2.0
+version=5.0.0
 
 kotlin.code.style=official
 
-kotlin.native.ignoreIncorrectDependencies=true
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.stability.nowarn=true
 
@@ -13,3 +12,4 @@ org.gradle.jvmargs=-Xmx6g
 kotlin.ignore.tcsm.overflow=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/src/commonMain/kotlin/com/configcat/Constants.kt
+++ b/src/commonMain/kotlin/com/configcat/Constants.kt
@@ -12,7 +12,7 @@ internal interface Closeable {
 }
 
 internal object Constants {
-    const val VERSION: String = "4.2.0"
+    const val VERSION: String = "5.0.0"
     const val CONFIG_FILE_NAME: String = "config_v6.json"
     const val SERIALIZATION_FORMAT_VERSION: String = "v2"
     const val GLOBAL_CDN_URL = "https://cdn-global.configcat.com"

--- a/src/commonMain/kotlin/com/configcat/SnapshotBuilder.kt
+++ b/src/commonMain/kotlin/com/configcat/SnapshotBuilder.kt
@@ -1,0 +1,61 @@
+package com.configcat
+
+import com.configcat.log.InternalLogger
+import com.configcat.override.FlagOverrides
+import com.configcat.override.OverrideBehavior
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+
+internal class SnapshotBuilder(
+    private val flagEvaluator: FlagEvaluator,
+    private val flagOverrides: FlagOverrides?,
+    private val logger: InternalLogger,
+    defaultUser: ConfigCatUser?,
+) {
+    public val defaultUser: AtomicRef<ConfigCatUser?> = atomic(defaultUser)
+
+    public fun buildSnapshot(inMemoryResult: InMemoryResult): ConfigCatClientSnapshot {
+        val inMemorySettings = calcInMemorySettingsWithOverrides(inMemoryResult)
+        return Snapshot(
+            flagEvaluator,
+            inMemorySettings.settingResult,
+            inMemorySettings.cacheState,
+            defaultUser.value,
+            logger,
+        )
+    }
+
+    private fun calcInMemorySettingsWithOverrides(inMemoryResult: InMemoryResult): InMemoryResult {
+        if (flagOverrides != null) {
+            return when (flagOverrides.behavior) {
+                OverrideBehavior.LOCAL_ONLY ->
+                    InMemoryResult(
+                        SettingResult(
+                            flagOverrides.dataSource.getOverrides(),
+                            Constants.distantPast,
+                        ),
+                        ClientCacheState.HAS_LOCAL_OVERRIDE_FLAG_DATA_ONLY,
+                    )
+
+                OverrideBehavior.LOCAL_OVER_REMOTE -> {
+                    val remote = inMemoryResult.settingResult.settings
+                    val local = flagOverrides.dataSource.getOverrides()
+                    InMemoryResult(
+                        SettingResult(remote + local, inMemoryResult.settingResult.fetchTime),
+                        inMemoryResult.cacheState,
+                    )
+                }
+
+                OverrideBehavior.REMOTE_OVER_LOCAL -> {
+                    val remote = inMemoryResult.settingResult.settings
+                    val local = flagOverrides.dataSource.getOverrides()
+                    InMemoryResult(
+                        SettingResult(local + remote, inMemoryResult.settingResult.fetchTime),
+                        inMemoryResult.cacheState,
+                    )
+                }
+            }
+        }
+        return inMemoryResult
+    }
+}

--- a/src/commonTest/kotlin/com/configcat/ConfigCatClientTests.kt
+++ b/src/commonTest/kotlin/com/configcat/ConfigCatClientTests.kt
@@ -895,7 +895,7 @@ class ConfigCatClientTests {
                 httpEngine = mockEngine
                 pollingMode = autoPoll { pollingInterval = 2.seconds }
                 offline = true
-                hooks.addOnClientReady { clientCacheState-> ready = clientCacheState }
+                hooks.addOnClientReady { clientCacheState: ClientCacheState -> ready = clientCacheState }
             }
 
             assertEquals(0, mockEngine.requestHistory.size)
@@ -1075,9 +1075,9 @@ class ConfigCatClientTests {
                 ConfigCatClient(TestUtils.randomSdkKey()) {
                     httpEngine = mockEngine
                     pollingMode = manualPoll()
-                    hooks.addOnConfigChanged { changed = true }
-                    hooks.addOnClientReady { clientReadyState -> readyWithClientState = clientReadyState }
-                    hooks.addOnClientReady { -> ready = true}
+                    hooks.addOnConfigChanged { settings, snapshot -> changed = true }
+                    hooks.addOnClientReady { clientCacheState: ClientCacheState -> readyWithClientState = clientCacheState }
+                    hooks.addOnClientReadyWithSnapshot { snapshot: ConfigCatClientSnapshot -> ready = true}
                     hooks.addOnError { err -> error = err }
                 }
 
@@ -1118,7 +1118,7 @@ class ConfigCatClientTests {
                     pollingMode = manualPoll()
                 }
 
-            client.hooks.addOnConfigChanged { changed = true }
+            client.hooks.addOnConfigChanged { settings, snapshot -> changed = true }
             client.hooks.addOnError { err -> error = err }
 
             client.forceRefresh()
@@ -1143,7 +1143,7 @@ class ConfigCatClientTests {
                 ConfigCatClient(TestUtils.randomSdkKey()) {
                     pollingMode = manualPoll()
                     configCache = cache
-                    hooks.addOnClientReady { clientReadyState -> ready = clientReadyState }
+                    hooks.addOnClientReady { clientReadyState: ClientCacheState -> ready = clientReadyState }
                 }
 
             TestUtils.awaitUntil {
@@ -1163,7 +1163,7 @@ class ConfigCatClientTests {
                 ConfigCatClient(TestUtils.randomSdkKey()) {
                     flagOverrides = { behavior = OverrideBehavior.LOCAL_ONLY }
                     pollingMode = manualPoll()
-                    hooks.addOnClientReady { clientReadyState -> ready = clientReadyState }
+                    hooks.addOnClientReady { clientReadyState: ClientCacheState -> ready = clientReadyState }
                 }
 
             assertEquals(ClientCacheState.HAS_LOCAL_OVERRIDE_FLAG_DATA_ONLY, ready)
@@ -1189,8 +1189,8 @@ class ConfigCatClientTests {
                 ConfigCatClient(TestUtils.randomSdkKey()) {
                     httpEngine = mockEngine
                     pollingMode = autoPoll()
-                    hooks.addOnConfigChanged { changed = true }
-                    hooks.addOnClientReady { clientReadyState -> ready = clientReadyState }
+                    hooks.addOnConfigChanged { settings, snapshot -> changed = true }
+                    hooks.addOnClientReady { clientReadyState: ClientCacheState -> ready = clientReadyState }
                     hooks.addOnError { err -> error = err }
                 }
 

--- a/src/commonTest/kotlin/com/configcat/SnapshotTests.kt
+++ b/src/commonTest/kotlin/com/configcat/SnapshotTests.kt
@@ -3,6 +3,7 @@ package com.configcat
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import korlibs.time.DateTime
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -82,6 +83,156 @@ class SnapshotTests {
 
             val anyVal = snapshot.getAnyValue("key1", false, null)
             assertEquals(true, anyVal)
+
+            client.close()
+        }
+
+    @Test
+    fun testHookSnapshot() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(content = Data.MULTIPLE_BODY, status = HttpStatusCode.OK)
+                }
+            var called = false
+            val client =
+                ConfigCatClient(TestUtils.randomSdkKey()) {
+                    httpEngine = mockEngine
+                    hooks.addOnConfigChanged { settings, snapshot ->
+                        assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, snapshot.cacheState)
+                        val value = snapshot.getValue("key1", false)
+                        assertTrue(value)
+
+                        val anyVal = snapshot.getAnyValue("key1", false, null)
+                        assertEquals(true, anyVal)
+                        called = true
+                    }
+                }
+
+            val state = client.waitForReady()
+            assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, state)
+
+            TestUtils.awaitUntil { called }
+
+            client.close()
+        }
+
+    @Test
+    fun testReadyHookSnapshot() =
+        runTest {
+            val mockEngine =
+                MockEngine {
+                    respond(content = Data.MULTIPLE_BODY, status = HttpStatusCode.OK)
+                }
+            var called = false
+            val client =
+                ConfigCatClient(TestUtils.randomSdkKey()) {
+                    httpEngine = mockEngine
+                    hooks.addOnClientReadyWithSnapshot { snapshot ->
+                        assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, snapshot.cacheState)
+                        val value = snapshot.getValue("key1", false)
+                        assertTrue(value)
+
+                        val anyVal = snapshot.getAnyValue("key1", false, null)
+                        assertEquals(true, anyVal)
+                        called = true
+                    }
+                }
+
+            val state = client.waitForReady()
+            assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, state)
+
+            TestUtils.awaitUntil { called }
+
+            client.close()
+        }
+
+    @Test
+    fun testHookSnapshotCache() =
+        runTest {
+            val cache = SingleValueCache(Data.formatCacheEntry("test"))
+
+            val mockEngine =
+                MockEngine {
+                    respond(content = "", status = HttpStatusCode.InternalServerError)
+                }
+            var called = false
+            val client =
+                ConfigCatClient(TestUtils.randomSdkKey()) {
+                    httpEngine = mockEngine
+                    configCache = cache
+                    hooks.addOnConfigChanged { settings, snapshot ->
+                        assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, snapshot.cacheState)
+                        val value = snapshot.getValue("fakeKey", "")
+                        assertEquals("test", value)
+                        called = true
+                    }
+                }
+
+            val state = client.waitForReady()
+            assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, state)
+
+            TestUtils.awaitUntil { called }
+
+            client.close()
+        }
+
+    @Test
+    fun testReadyHookSnapshotCache() =
+        runTest {
+            val cache = SingleValueCache(Data.formatCacheEntry("test"))
+
+            val mockEngine =
+                MockEngine {
+                    respond(content = "", status = HttpStatusCode.InternalServerError)
+                }
+            var called = false
+            val client =
+                ConfigCatClient(TestUtils.randomSdkKey()) {
+                    httpEngine = mockEngine
+                    configCache = cache
+                    hooks.addOnClientReadyWithSnapshot { snapshot ->
+                        assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, snapshot.cacheState)
+                        val value = snapshot.getValue("fakeKey", "")
+                        assertEquals("test", value)
+                        called = true
+                    }
+                }
+
+            val state = client.waitForReady()
+            assertEquals(ClientCacheState.HAS_UP_TO_DATE_FLAG_DATA, state)
+
+            TestUtils.awaitUntil { called }
+
+            client.close()
+        }
+
+    @Test
+    fun testHookSnapshotCacheExpired() =
+        runTest {
+            val cache = SingleValueCache(Data.formatCacheEntryWithDate("test", Constants.distantPast))
+
+            val mockEngine =
+                MockEngine {
+                    respond(content = "", status = HttpStatusCode.InternalServerError)
+                }
+            var called = false
+            val client =
+                ConfigCatClient(TestUtils.randomSdkKey()) {
+                    httpEngine = mockEngine
+                    configCache = cache
+                    hooks.addOnConfigChanged { settings, snapshot ->
+                        assertEquals(ClientCacheState.HAS_CACHED_FLAG_DATA_ONLY, snapshot.cacheState)
+                        val value = snapshot.getValue("fakeKey", "")
+                        assertEquals("test", value)
+                        called = true
+                    }
+                }
+
+            val state = client.waitForReady()
+            assertEquals(ClientCacheState.HAS_CACHED_FLAG_DATA_ONLY, state)
+
+            TestUtils.awaitUntil { called }
 
             client.close()
         }

--- a/src/commonTest/kotlin/com/configcat/Utils.kt
+++ b/src/commonTest/kotlin/com/configcat/Utils.kt
@@ -208,11 +208,16 @@ internal object Services {
         options.configCache = cache
         options.hooks = hooks
         options.offline = offline
+        val logger = InternalLogger(options.logger, options.logLevel, hooks)
         val service =
             ConfigService(
                 options,
+                SnapshotBuilder(FlagEvaluator(
+                    logger, Evaluator(logger),
+                    hooks = hooks
+                ), null, logger, null),
                 createFetcher(engine, options = options),
-                InternalLogger(options.logger, options.logLevel, hooks),
+        logger,
                 hooks,
             )
         closeables.add(service)


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR contains the following:

**Added**
- `addOnClientReadyWithSnapshot(snapshotHandler: (ConfigCatClientSnapshot) -> Unit)` hook subscription function that gets a snapshot whenever the client reaches the ready state.
- `addOnConfigChanged(handler: (Map<String, Setting>, ConfigCatClientSnapshot) -> Unit)` hook subscription function that also gets a snapshot (beside the settings map) about the changed config state of the client.

**Breaking changes**
- Depreceted `addOnClientReady(handler: () -> Unit)` hook subscription function was removed.
- Signature of the `addOnConfigChanged()` hook subscription function changed from `addOnConfigChanged(handler: (Map<String, Setting>) -> Unit)` to `addOnConfigChanged(handler: (Map<String, Setting>, ConfigCatClientSnapshot) -> Unit)`.

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
